### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Rust CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/varubogu/gbf_discord_bot_rs/security/code-scanning/2](https://github.com/varubogu/gbf_discord_bot_rs/security/code-scanning/2)

In general, to fix this issue you explicitly declare `permissions:` either at the workflow level or for each job, setting the minimum scopes required. For simple CI that just checks out code and runs tests, `contents: read` is typically sufficient, as it allows reading the repository but not pushing commits, creating releases, etc.

The best fix here, without changing existing functionality, is to add a top‑level `permissions:` block right under the workflow `name:` (or under `on:`), applying to all jobs. Since the `test` job only checks out the code and runs `cargo` commands, we can safely restrict the token to `contents: read`. No other scopes (`actions`, `pull-requests`, etc.) are required based on the provided snippet.

Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after line 2, before the `on:` block). No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
