### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ignored-db-tests.yml
+++ b/.github/workflows/ignored-db-tests.yml
@@ -11,6 +11,9 @@ on:
     # - コスト優先にする場合は push(main/develop) へ寄せる運用も検討可能
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ignored-db-tests-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/varubogu/gbf_discord_bot_rs/security/code-scanning/1](https://github.com/varubogu/gbf_discord_bot_rs/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required by the workflow, either at the workflow root (applies to all jobs) or within the specific job. Since this workflow just checks out code and runs DB‑backed tests, it only needs read access to repository contents. It does not create or modify issues, pull requests, releases, or other GitHub resources, so no write permissions are required.

The best minimal fix without changing functionality is to add a workflow‑level `permissions` block restricting `GITHUB_TOKEN` to `contents: read`. This should be placed near the top of `.github/workflows/ignored-db-tests.yml`, after the `on:` block and before `concurrency:` to follow common style, but any top‑level position is valid. No additional imports, steps, or tools are needed; the change is purely declarative in YAML. The job itself does not need its own `permissions` block, since inheriting the root restrictions is sufficient.

Concretely:
- Edit `.github/workflows/ignored-db-tests.yml`.
- After line 12 (the `cron` schedule definition) and the following blank line, insert:

```yaml
permissions:
  contents: read
```

This will ensure that all jobs in this workflow, including `ignored-db-tests`, run with a read‑only `GITHUB_TOKEN` on repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
